### PR TITLE
Add `session_max_current` state to confirm reservation limit

### DIFF
--- a/number.py
+++ b/number.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.const import UnitOfElectricCurrent
 
 from .coordinator import EVSEMasterDataUpdateCoordinator, DataSchema
 from .evse_loader import data_types
@@ -50,7 +51,7 @@ class EVSEMaxAmpsNumber(_BaseNumber, NumberEntity):
     _attr_icon = "mdi:flash"
     _attr_native_min_value = 6
     _attr_native_step = 1
-    _attr_native_unit_of_measurement = "A"
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
 
     def __init__(self, coordinator: EVSEMasterDataUpdateCoordinator) -> None:
         super().__init__(coordinator)

--- a/sensor.py
+++ b/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfPower,UnitOfEnergy,UnitOfTemperature, UnitOfTime
+from homeassistant.const import UnitOfPower,UnitOfEnergy,UnitOfTemperature, UnitOfTime, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -40,7 +40,8 @@ async def async_setup_entry(
     entities.append(EVSETotalKwhSensor(coordinator))
     entities.append(EVSEChargeKwhSensor(coordinator))
     entities.append(EVSEChargeDurationSensor(coordinator))
-    entities.append(EVSEStartDatetimeSensor(coordinator))
+    entities.append(EVSESessionStartDatetimeSensor(coordinator))
+    entities.append(EVSESessionMaxCurrentSensor(coordinator))
     entities.append(EVSEReservationDatetimeSensor(coordinator))
     entities.append(EVSEReservationDurationSensor(coordinator))
 
@@ -190,7 +191,7 @@ class EVSEChargeDurationSensor(_Base, SensorEntity):
             return cstatus.duration_seconds
 
 
-class EVSEStartDatetimeSensor(_Base, SensorEntity):
+class EVSESessionStartDatetimeSensor(_Base, SensorEntity):
     _attr_translation_key = "session_start_datetime"
     _attr_device_class = SensorDeviceClass.TIMESTAMP
 
@@ -203,6 +204,23 @@ class EVSEStartDatetimeSensor(_Base, SensorEntity):
         cstatus = self.entry.charging_status
         if cstatus and isinstance(cstatus.set_datetime, datetime):
             return cstatus.set_datetime
+        return None
+
+
+class EVSESessionMaxCurrentSensor(_Base, SensorEntity):
+    _attr_translation_key = "session_max_current"
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+    _attr_device_class = SensorDeviceClass.CURRENT
+
+    def __init__(self, coordinator: EVSEMasterDataUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self.entry.device.serial_number}_session_max_current"
+
+    @property
+    def native_value(self) -> int | None:
+        cstatus = self.entry.charging_status
+        if cstatus:
+            return cstatus.max_electricity
         return None
 
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -53,16 +53,19 @@
         "name": "Outer Temperature"
       },
       "total_kwh": {
-        "name": "Total kWh"
+        "name": "Total Energy"
       },
       "charge_kwh": {
-        "name": "Session kWh"
+        "name": "Session Energy"
       },
       "charge_duration": {
         "name": "Session Duration"
       },
       "session_start_datetime": {
         "name": "Session Start"
+      },
+      "session_max_current": {
+        "name": "Session Max Current"
       },
       "reservation_datetime": {
         "name": "Reservation Start Time"


### PR DESCRIPTION
I noticed while experimenting with reserving a charge via the action that `max_amps` never got updated with the requested value.  It appears the `OUTPUT_AMPERAGE_EVENT` is never received (perhaps because it only triggers after a login or when charging commences) making `max_electricity` in the charging session status the only field indicating that the requested current limit is actually confirmed.

---

It seems that changing the `Max Amps` slider in the UI however is able to affect things such as an existing charging reservation; `max_electricity` changes again accordingly in the next `CURRENT_CHARGING_STATUS_EVENT`.  It's not clear to me yet if I should perhaps just let this field affect the existing `DeviceInfo.configured_max_amps` field instead?
