### PR TITLE
services: Limit target "entity" selection to EVSEMaster

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -2,7 +2,7 @@ start_charging:
   name: Start Charging
   description: Start charging with advanced parameters
   target:
-    device:
+    entity:
       integration: evsemaster
   fields:
     max_amps:


### PR DESCRIPTION
We already discussed in 4c296a8e43924ecd18b35be9881847b93e9ad515 that while only the EVSEMaster device is shown, it also shows _all_ entities across the entirety of HASS.

I also just found at https://developers.home-assistant.io/blog/2025/10/14/device-filter-removed-from-target-selector that the `device:` filter is deprecated and being removed in 2026.11 meaning we have to stick to the `entity:` filter.  Unfortunately this still shows all entities and when exclusively selecting those no `device_id` array is passed into the integration (unused anyway because the underlying `evsemaster` Python library doesn't yet support discovery and multiple devices).

There doesn't seem to be any other functionality to filter on from https://www.home-assistant.io/docs/blueprint/selectors/#target-selector besides the integration domain (which is already `evsemaster` here).

In the end more investigation is required, perhaps a custom field instead where we _can_ use https://www.home-assistant.io/docs/blueprint/selectors/#device-selector. But it's all irrelevant for now since `device_id` is unused (and `dict.get()` would return `None` if the field was missing anyway) so having to select a target is only a nuisance to the user.
